### PR TITLE
docs: project coherence system (STATUS matrix + per-port detail + propagation labels)

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,29 @@
+## Summary
+
+<!-- One-paragraph description of what this PR does and why. -->
+
+## Coherence checklist
+
+- [ ] **Did this change a `docs/STATUS.md` cell?** If yes, describe which row × column changed and why.
+- [ ] **Does this fix or add something that should propagate to other ports?** If yes, list the ports and either (a) include the fix for them in this PR, or (b) open follow-up issues with `propagate:<port>` labels and link them below.
+
+## Affected ports / branches
+
+<!-- Tick all that apply. -->
+
+- [ ] `metal` (main)
+- [ ] `cuda`
+- [ ] `cuda-qwen36`
+- [ ] `cuda-kimi`
+- [ ] `rocm`
+- [ ] `mi300-opt`
+- [ ] `apu`
+
+## Reliability impact
+
+<!-- Does this move us toward or away from the reliability bar
+(multi-turn agent loop + small fixed eval) for any port? -->
+
+## Linked issues
+
+<!-- Link any issues this closes or follows up on. -->

--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,10 @@ logs/
 metal_infer/test_lzfse
 metal_infer/repack_experts_lz4
 metal_infer/routing_data.bin
+
+# Private working notes — designs, implementation plans, strategy docs.
+# Keep these local; do NOT push to GitHub. Older plans already on
+# fork/rocm and fork/apu remain public for history; new work stays
+# behind this gate.
+docs/superpowers/
+docs/plan-*.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,6 +6,14 @@ Pure C/Metal inference engine that runs **Qwen3.5-397B-A17B** (a 397 billion par
 
 The entire 209GB model streams from SSD through a custom Metal compute pipeline. No Python. No frameworks. Just C, Objective-C, and hand-tuned Metal shaders.
 
+## Project status
+
+**What works on which backend, with which model:** see [`docs/STATUS.md`](docs/STATUS.md).
+
+Per-port detail in [`docs/ports/<port>.md`](docs/ports/).
+
+A cell is allowed to be ✅ only when the model on that backend has cleared the project reliability bar: a multi-turn agent loop (5+ tool calls, file edits, no drift) plus a small fixed eval. Working mechanism without that test stays 🟡.
+
 ## Results
 
 ![Progress](progress.png)

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -1,0 +1,66 @@
+# Flash-MoE — Project Status
+
+> **Source of truth:** "what can this project do, on which backend, with which model."
+> **Updated by:** PRs that change a capability cell.
+> **Detail per port:** see `docs/ports/<port>.md`.
+
+## Cell legend
+
+| Symbol | Meaning |
+|---|---|
+| ✅ | shipped & tool-call-tested |
+| 🟡 | works but partial / unstable |
+| ❌ | broken / missing |
+| `—` | not applicable for this combination |
+
+## Coarse capability matrix
+
+Columns are `<backend> × <model>`. Rows are user-visible capabilities.
+
+| Capability | Metal × Qwen3.5-397B | Metal × Qwen3.6 | Metal × Kimi | CUDA × Qwen3.5-397B | CUDA × Qwen3.6 | CUDA × Kimi | ROCm × Qwen3.5-397B | ROCm × Qwen3.6 | ROCm × Kimi | APU × Qwen3.5-397B | APU × Qwen3.6 | APU × Kimi |
+|---|---|---|---|---|---|---|---|---|---|---|---|---|
+| Run model end-to-end | ✅ | — | — | ✅ | ✅ | ❌ | ✅ | — | — | ❌ | — | — |
+| Tool calling (JSON-stable) | ✅ | — | — | ❌ | ❌ | ❌ | ❌ | — | — | ❌ | — | — |
+| Multi-turn agent loop | ❌ | — | — | ❌ | ❌ | ❌ | ❌ | — | — | ❌ | — | — |
+| HTTP/SSE serve mode (OpenAI-compatible) | ✅ | — | — | ✅ | ❌ | ❌ | ❌ | — | — | ❌ | — | — |
+| Streaming SSD experts | ✅ | — | — | ✅ | ✅ | ✅ | ✅ | — | — | 🟡 | — | — |
+| VRAM/RAM LRU expert cache | — | — | — | ❌ | ✅ | 🟡 | ✅ | — | — | ❌ | — | — |
+| FP8 quant (e4m3 block-128) | — | — | — | — | ✅ | — | — | — | — | — | — | — |
+| int4 quant (custom pack) | ✅ | — | — | ✅ | — | — | ✅ | — | — | 🟡 | — | — |
+| sym-int4 quant (compressed-tensors) | — | — | — | — | — | ✅ | — | — | — | — | — | — |
+| MLA attention | — | — | — | — | — | ✅ | — | — | — | — | — | — |
+| GatedDeltaNet (linear attention) | ✅ | — | — | ✅ | ✅ | — | ✅ | — | — | 🟡 | — | — |
+| Full attention with output-gate | — | — | — | — | ✅ | — | — | — | — | — | — | — |
+| RoPE (full + partial) | ✅ | — | — | ✅ | ✅ | 🟡 | ✅ | — | — | 🟡 | — | — |
+| Tokenizer subprocess | — | — | — | ✅ | ✅ | ✅ | ✅ | — | — | 🟡 | — | — |
+| Greedy + top-p sampling | ✅ | — | — | ✅ | ✅ | ❌ | ✅ | — | — | ❌ | — | — |
+
+## Reliability bar
+
+A cell is allowed to be ✅ only when the model on that backend has cleared the project bar from the design spec:
+1. Multi-turn agent loop (5+ tool calls, file edits, no drift)
+2. Small fixed eval pass (~10s of prompts; benchmark vs reference vLLM/HF)
+
+If a capability works but the model has *not* cleared the reliability bar, downgrade the cell to 🟡 even if the underlying mechanism is solid.
+
+## How to update this file
+
+1. PR that changes a cell must justify the change in the PR description.
+2. PR template (`.github/PULL_REQUEST_TEMPLATE.md`) reminds you to check this matrix before merging.
+3. If a cell's status changes due to a fix on one branch, open a follow-up issue with `propagate:*` labels for the other ports that need the same fix.
+
+## Per-port detail
+
+| Port (branch) | Doc |
+|---|---|
+| Metal (`main`) | [`ports/metal.md`](ports/metal.md) |
+| CUDA (`cuda`) | [`ports/cuda.md`](ports/cuda.md) |
+| CUDA Qwen3.6 (`cuda-qwen36`) — **priority port** | [`ports/cuda-qwen36.md`](ports/cuda-qwen36.md) |
+| CUDA Kimi (`cuda-kimi`) | [`ports/cuda-kimi.md`](ports/cuda-kimi.md) |
+| ROCm (`rocm`) | [`ports/rocm.md`](ports/rocm.md) |
+| MI300 optimization (`mi300-opt`) | [`ports/mi300-opt.md`](ports/mi300-opt.md) |
+| APU (`apu`) | [`ports/apu.md`](ports/apu.md) |
+
+## Provenance
+
+This file is the public canonical capability matrix. Underlying design rationale and implementation plan are kept as private working notes outside the repo (see `.gitignore`).

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -19,21 +19,21 @@ Columns are `<backend> × <model>`. Rows are user-visible capabilities.
 
 | Capability | Metal × Qwen3.5-397B | Metal × Qwen3.6 | Metal × Kimi | CUDA × Qwen3.5-397B | CUDA × Qwen3.6 | CUDA × Kimi | ROCm × Qwen3.5-397B | ROCm × Qwen3.6 | ROCm × Kimi | APU × Qwen3.5-397B | APU × Qwen3.6 | APU × Kimi |
 |---|---|---|---|---|---|---|---|---|---|---|---|---|
-| Run model end-to-end | ✅ | — | — | ✅ | ✅ | ❌ | ✅ | — | — | ❌ | — | — |
-| Tool calling (JSON-stable) | ✅ | — | — | ❌ | ❌ | ❌ | ❌ | — | — | ❌ | — | — |
+| Run model end-to-end | 🟡 | — | — | 🟡 | 🟡 | ❌ | 🟡 | — | — | ❌ | — | — |
+| Tool calling (JSON-stable) | 🟡 | — | — | ❌ | ❌ | ❌ | ❌ | — | — | ❌ | — | — |
 | Multi-turn agent loop | ❌ | — | — | ❌ | ❌ | ❌ | ❌ | — | — | ❌ | — | — |
-| HTTP/SSE serve mode (OpenAI-compatible) | ✅ | — | — | ✅ | ❌ | ❌ | ❌ | — | — | ❌ | — | — |
-| Streaming SSD experts | ✅ | — | — | ✅ | ✅ | ✅ | ✅ | — | — | 🟡 | — | — |
-| VRAM/RAM LRU expert cache | — | — | — | ❌ | ✅ | 🟡 | ✅ | — | — | ❌ | — | — |
-| FP8 quant (e4m3 block-128) | — | — | — | — | ✅ | — | — | — | — | — | — | — |
-| int4 quant (custom pack) | ✅ | — | — | ✅ | — | — | ✅ | — | — | 🟡 | — | — |
-| sym-int4 quant (compressed-tensors) | — | — | — | — | — | ✅ | — | — | — | — | — | — |
-| MLA attention | — | — | — | — | — | ✅ | — | — | — | — | — | — |
-| GatedDeltaNet (linear attention) | ✅ | — | — | ✅ | ✅ | — | ✅ | — | — | 🟡 | — | — |
-| Full attention with output-gate | — | — | — | — | ✅ | — | — | — | — | — | — | — |
-| RoPE (full + partial) | ✅ | — | — | ✅ | ✅ | 🟡 | ✅ | — | — | 🟡 | — | — |
-| Tokenizer subprocess | — | — | — | ✅ | ✅ | ✅ | ✅ | — | — | 🟡 | — | — |
-| Greedy + top-p sampling | ✅ | — | — | ✅ | ✅ | ❌ | ✅ | — | — | ❌ | — | — |
+| HTTP/SSE serve mode (OpenAI-compatible) | 🟡 | — | — | 🟡 | ❌ | ❌ | ❌ | — | — | ❌ | — | — |
+| Streaming SSD experts | 🟡 | — | — | 🟡 | 🟡 | 🟡 | 🟡 | — | — | 🟡 | — | — |
+| VRAM/RAM LRU expert cache | — | — | — | ❌ | 🟡 | 🟡 | 🟡 | — | — | ❌ | — | — |
+| FP8 quant (e4m3 block-128) | — | — | — | — | 🟡 | — | — | — | — | — | — | — |
+| int4 quant (custom pack) | 🟡 | — | — | 🟡 | — | — | 🟡 | — | — | 🟡 | — | — |
+| sym-int4 quant (compressed-tensors) | — | — | — | — | — | 🟡 | — | — | — | — | — | — |
+| MLA attention | — | — | — | — | — | 🟡 | — | — | — | — | — | — |
+| GatedDeltaNet (linear attention) | 🟡 | — | — | 🟡 | 🟡 | — | 🟡 | — | — | 🟡 | — | — |
+| Full attention with output-gate | — | — | — | — | 🟡 | — | — | — | — | — | — | — |
+| RoPE (full + partial) | 🟡 | — | — | 🟡 | 🟡 | 🟡 | 🟡 | — | — | 🟡 | — | — |
+| Tokenizer subprocess | — | — | — | 🟡 | 🟡 | 🟡 | 🟡 | — | — | 🟡 | — | — |
+| Greedy + top-p sampling | 🟡 | — | — | 🟡 | 🟡 | ❌ | 🟡 | — | — | ❌ | — | — |
 
 ## Reliability bar
 

--- a/docs/ports/apu.md
+++ b/docs/ports/apu.md
@@ -1,0 +1,58 @@
+# Port: apu
+
+> **Branch:** `apu`
+> **Status:** stub — fill cells as capabilities are verified.
+> **Coarse summary:** see [`../STATUS.md`](../STATUS.md).
+
+## Capability matrix (detailed)
+
+Cell values: ✅ verified  ·  🟡 partial / unstable  ·  ❌ broken / missing  ·  `—` N/A.
+
+| # | Capability | Per-model status | Notes |
+|---|---|---|---|
+| 1 | Model loads end-to-end | | |
+| 2 | Greedy sampling | | |
+| 3 | Top-p / temperature sampling | | |
+| 4 | Tokenizer subprocess | | |
+| 5 | Tool calling (JSON-stable) | | |
+| 6 | Multi-turn agent loop | | |
+| 7 | HTTP/SSE serve mode | | |
+| 8 | Streaming SSD experts | | |
+| 9 | VRAM/RAM LRU expert cache | | |
+| 10 | int4 quant (custom pack) | | |
+| 11 | FP8 e4m3 block-128 quant | | |
+| 12 | sym-int4 (compressed-tensors) | | |
+| 13 | RoPE (full) | | |
+| 14 | RoPE (partial) | | |
+| 15 | RMSNorm (standard) | | |
+| 16 | RMSNorm-plus-one variant | | |
+| 17 | GatedDeltaNet (linear attention) | | |
+| 18 | Full attention with output-gate | | |
+| 19 | MLA attention | | |
+| 20 | MoE routing (softmax+topK) | | |
+| 21 | MoE routing (noaux_tc sigmoid+bias) | | |
+| 22 | Shared expert | | |
+| 23 | Embed tensor `>2GB` load (chunked pread) | | |
+| 24 | Per-substep oracle validation | | |
+| 25 | Per-layer L2 sanity vs oracle | | |
+| 26 | End-to-end top-1 bit-match vs oracle | | |
+| 27 | K-head replication correctness | | |
+| 28 | Conv1d output position handling | | |
+| 29 | Weight absorption (`W_Q_abs`, `W_O_abs`) | | |
+| 30 | Build target in Makefile | | |
+
+## Models
+
+List models known to run on this port. Empty = none verified.
+
+| Model | Status | tok/s (warm) | Last verified |
+|---|---|---|---|
+| | | | |
+
+## Known-good commit
+
+`<commit-hash> — short description of last working state>`
+
+## Backlinks
+
+- [`../STATUS.md`](../STATUS.md) — coarse project capability matrix

--- a/docs/ports/cuda-kimi.md
+++ b/docs/ports/cuda-kimi.md
@@ -1,0 +1,58 @@
+# Port: cuda-kimi
+
+> **Branch:** `cuda-kimi`
+> **Status:** stub — fill cells as capabilities are verified.
+> **Coarse summary:** see [`../STATUS.md`](../STATUS.md).
+
+## Capability matrix (detailed)
+
+Cell values: ✅ verified  ·  🟡 partial / unstable  ·  ❌ broken / missing  ·  `—` N/A.
+
+| # | Capability | Per-model status | Notes |
+|---|---|---|---|
+| 1 | Model loads end-to-end | | |
+| 2 | Greedy sampling | | |
+| 3 | Top-p / temperature sampling | | |
+| 4 | Tokenizer subprocess | | |
+| 5 | Tool calling (JSON-stable) | | |
+| 6 | Multi-turn agent loop | | |
+| 7 | HTTP/SSE serve mode | | |
+| 8 | Streaming SSD experts | | |
+| 9 | VRAM/RAM LRU expert cache | | |
+| 10 | int4 quant (custom pack) | | |
+| 11 | FP8 e4m3 block-128 quant | | |
+| 12 | sym-int4 (compressed-tensors) | | |
+| 13 | RoPE (full) | | |
+| 14 | RoPE (partial) | | |
+| 15 | RMSNorm (standard) | | |
+| 16 | RMSNorm-plus-one variant | | |
+| 17 | GatedDeltaNet (linear attention) | | |
+| 18 | Full attention with output-gate | | |
+| 19 | MLA attention | | |
+| 20 | MoE routing (softmax+topK) | | |
+| 21 | MoE routing (noaux_tc sigmoid+bias) | | |
+| 22 | Shared expert | | |
+| 23 | Embed tensor `>2GB` load (chunked pread) | | |
+| 24 | Per-substep oracle validation | | |
+| 25 | Per-layer L2 sanity vs oracle | | |
+| 26 | End-to-end top-1 bit-match vs oracle | | |
+| 27 | K-head replication correctness | | |
+| 28 | Conv1d output position handling | | |
+| 29 | Weight absorption (`W_Q_abs`, `W_O_abs`) | | |
+| 30 | Build target in Makefile | | |
+
+## Models
+
+List models known to run on this port. Empty = none verified.
+
+| Model | Status | tok/s (warm) | Last verified |
+|---|---|---|---|
+| | | | |
+
+## Known-good commit
+
+`<commit-hash> — short description of last working state>`
+
+## Backlinks
+
+- [`../STATUS.md`](../STATUS.md) — coarse project capability matrix

--- a/docs/ports/cuda-qwen36.md
+++ b/docs/ports/cuda-qwen36.md
@@ -3,7 +3,7 @@
 > **Branch:** `cuda-qwen36`
 > **Status:** working at ~7-8 tok/s on RTX 4090 with VRAM LRU expert cache.
 > **Coarse summary:** see [`../STATUS.md`](../STATUS.md).
-> **Source notes:** [`Qwen3.6 Port` (Obsidian)](../../README.md) and `~/.claude/.../memory/project_qwen36_port.md`.
+> **Source notes:** local working notes (Obsidian "Qwen3.6 Port" + `~/.claude/projects/-home-sergey-flash-moe/memory/project_qwen36_port.md`).
 
 ## Capability matrix (detailed) — model: Qwen3.6-35B-A3B-FP8
 

--- a/docs/ports/cuda-qwen36.md
+++ b/docs/ports/cuda-qwen36.md
@@ -1,57 +1,75 @@
 # Port: cuda-qwen36
 
 > **Branch:** `cuda-qwen36`
-> **Status:** stub — fill cells as capabilities are verified.
+> **Status:** working at ~7-8 tok/s on RTX 4090 with VRAM LRU expert cache.
 > **Coarse summary:** see [`../STATUS.md`](../STATUS.md).
+> **Source notes:** [`Qwen3.6 Port` (Obsidian)](../../README.md) and `~/.claude/.../memory/project_qwen36_port.md`.
 
-## Capability matrix (detailed)
+## Capability matrix (detailed) — model: Qwen3.6-35B-A3B-FP8
 
 Cell values: ✅ verified  ·  🟡 partial / unstable  ·  ❌ broken / missing  ·  `—` N/A.
 
-| # | Capability | Per-model status | Notes |
+| # | Capability | Status | Notes |
 |---|---|---|---|
-| 1 | Model loads end-to-end | | |
-| 2 | Greedy sampling | | |
-| 3 | Top-p / temperature sampling | | |
-| 4 | Tokenizer subprocess | | |
-| 5 | Tool calling (JSON-stable) | | |
-| 6 | Multi-turn agent loop | | |
-| 7 | HTTP/SSE serve mode | | |
-| 8 | Streaming SSD experts | | |
-| 9 | VRAM/RAM LRU expert cache | | |
-| 10 | int4 quant (custom pack) | | |
-| 11 | FP8 e4m3 block-128 quant | | |
-| 12 | sym-int4 (compressed-tensors) | | |
-| 13 | RoPE (full) | | |
-| 14 | RoPE (partial) | | |
-| 15 | RMSNorm (standard) | | |
-| 16 | RMSNorm-plus-one variant | | |
-| 17 | GatedDeltaNet (linear attention) | | |
-| 18 | Full attention with output-gate | | |
-| 19 | MLA attention | | |
-| 20 | MoE routing (softmax+topK) | | |
-| 21 | MoE routing (noaux_tc sigmoid+bias) | | |
-| 22 | Shared expert | | |
-| 23 | Embed tensor `>2GB` load (chunked pread) | | |
-| 24 | Per-substep oracle validation | | |
-| 25 | Per-layer L2 sanity vs oracle | | |
-| 26 | End-to-end top-1 bit-match vs oracle | | |
-| 27 | K-head replication correctness | | |
-| 28 | Conv1d output position handling | | |
-| 29 | Weight absorption (`W_Q_abs`, `W_O_abs`) | | |
-| 30 | Build target in Makefile | | |
+| 1 | Model loads end-to-end | ✅ | 40 layers + globals; `~3.7 GB` persistent + `~1 GB` scratch |
+| 2 | Greedy sampling | ✅ | `--greedy` flag |
+| 3 | Top-p / temperature sampling | ✅ | `--temp 0.7 --top-p 0.9` |
+| 4 | Tokenizer subprocess | ✅ | `kimi_tokenize.py serve --model-dir <path>` (generic across HF tokenizers; KIMI prefix historical) |
+| 5 | Tool calling (JSON-stable) | ❌ | not implemented |
+| 6 | Multi-turn agent loop | ❌ | not implemented |
+| 7 | HTTP/SSE serve mode | ❌ | not ported (Qwen3.5-397B `infer.cu` has the OpenAI-compatible server — porting is on the wishlist) |
+| 8 | Streaming SSD experts | ✅ | one 3.1 MB pread per active expert from `packed_experts/layer_N.bin` |
+| 9 | VRAM/RAM LRU expert cache | ✅ | `q36::ExpertCache`, capacity × 3.1 MB pool, O(1) LRU; 6000 slots = 18.9 GB; 74% hit at warm steady-state |
+| 10 | int4 quant (custom pack) | — | Qwen3.6-FP8 doesn't use it |
+| 11 | FP8 e4m3 block-128 quant | ✅ | `qwen36::fp8_block_matvec`, max_abs `~1e-7` vs oracle |
+| 12 | sym-int4 (compressed-tensors) | — | Kimi-only |
+| 13 | RoPE (full) | — | Qwen3.6 uses partial only |
+| 14 | RoPE (partial) | ✅ | `rope_partial_inplace` on first 64 of 256 dims (`partial_rotary_factor=0.25`, `rope_theta=1e7`) |
+| 15 | RMSNorm (standard) | ✅ | gated variant uses `weight*normalized*silu(z)` |
+| 16 | RMSNorm-plus-one variant | ✅ | `qwen36::rms_norm_bf16_plus_one` and `rms_norm_per_row_plus_one` for `(1+w)*normalized` semantics |
+| 17 | GatedDeltaNet (linear attention) | ✅ | layers 0,1,2 then 4,5,6 …; chunked Q/K replicate 16→32 heads, k_heads_per_v=1 to avoid double-divide |
+| 18 | Full attention with output-gate | ✅ | layers 3,7,11,…,39; `attn_output_gate=true`, sigmoid(gate) on output |
+| 19 | MLA attention | — | Kimi-only |
+| 20 | MoE routing (softmax+topK) | ✅ | router bf16 [256,2048] → softmax → top-K=8 → renorm |
+| 21 | MoE routing (noaux_tc sigmoid+bias) | — | Kimi-only |
+| 22 | Shared expert | ✅ | `sigmoid(shared_expert_gate(h)) * shared_expert_out` |
+| 23 | Embed tensor `>2GB` load (chunked pread) | 🟡 | not verified; Qwen3.6 embed is `~1 GB` so the bug latent in Kimi (fixed there) doesn't bite. Worth verifying defensively — see seed issue. |
+| 24 | Per-substep oracle validation | ✅ | `test_qwen36_linear_attn`, `test_qwen36_moe`, `test_qwen36_full_attn` |
+| 25 | Per-layer L2 sanity vs oracle | ✅ | `test_qwen36_layer` at L2rel `~1-2%` |
+| 26 | End-to-end top-1 bit-match vs oracle | ✅ | `test_qwen36_chain` — top-1 next-token bit-exact for all 5 prompt positions; final logits L2rel 2-6% |
+| 27 | K-head replication correctness | ✅ | host-side repeat_interleave 16→32, downstream `k_heads_per_v=1` (bug discovered + fixed during port) |
+| 28 | Conv1d output position handling | ✅ | `F.conv1d(padding=K-1=3)` → take `[:seq_len]` (positions 0..4, NOT 3..7) |
+| 29 | Weight absorption | — | Kimi-only |
+| 30 | Build target in Makefile | ✅ | `make infer_qwen36` (`-arch=sm_89`) |
 
 ## Models
 
-List models known to run on this port. Empty = none verified.
-
 | Model | Status | tok/s (warm) | Last verified |
 |---|---|---|---|
-| | | | |
+| Qwen3.6-35B-A3B-FP8 | ✅ working | 7-8 (warm + VRAM cache 6000 slots) | 2026-04-24 (per source memory) |
 
 ## Known-good commit
 
-`<commit-hash> — short description of last working state>`
+`5198058 — qwen3.6: shared LRU expert cache in VRAM (--cache-experts N)`
+
+## Run
+
+```bash
+./infer_qwen36 \
+  --model-dir /home/user1/qwen36-fp8 \
+  --packed-dir /home/user1/qwen36-fp8/packed_experts \
+  --cache-experts 6000 \
+  --prompt "..." --max-tokens 64 [--greedy | --temp 0.7 --top-p 0.9]
+```
+
+## Open work (from spec North Star — reliability before throughput)
+
+The "reliability" bar for this port (multi-turn agent loop + small fixed eval) is **not yet met**. Cells 5-7 are the gap:
+- HTTP/SSE serve mode (port from Qwen3.5-397B's `infer.cu`)
+- Tool calling (JSON-stable)
+- Multi-turn agent loop
+
+Throughput optimization plans (CUDA stream overlap, prefill batching) are paused per the design spec until cells 5, 6, 7 turn ✅.
 
 ## Backlinks
 

--- a/docs/ports/cuda-qwen36.md
+++ b/docs/ports/cuda-qwen36.md
@@ -1,0 +1,58 @@
+# Port: cuda-qwen36
+
+> **Branch:** `cuda-qwen36`
+> **Status:** stub — fill cells as capabilities are verified.
+> **Coarse summary:** see [`../STATUS.md`](../STATUS.md).
+
+## Capability matrix (detailed)
+
+Cell values: ✅ verified  ·  🟡 partial / unstable  ·  ❌ broken / missing  ·  `—` N/A.
+
+| # | Capability | Per-model status | Notes |
+|---|---|---|---|
+| 1 | Model loads end-to-end | | |
+| 2 | Greedy sampling | | |
+| 3 | Top-p / temperature sampling | | |
+| 4 | Tokenizer subprocess | | |
+| 5 | Tool calling (JSON-stable) | | |
+| 6 | Multi-turn agent loop | | |
+| 7 | HTTP/SSE serve mode | | |
+| 8 | Streaming SSD experts | | |
+| 9 | VRAM/RAM LRU expert cache | | |
+| 10 | int4 quant (custom pack) | | |
+| 11 | FP8 e4m3 block-128 quant | | |
+| 12 | sym-int4 (compressed-tensors) | | |
+| 13 | RoPE (full) | | |
+| 14 | RoPE (partial) | | |
+| 15 | RMSNorm (standard) | | |
+| 16 | RMSNorm-plus-one variant | | |
+| 17 | GatedDeltaNet (linear attention) | | |
+| 18 | Full attention with output-gate | | |
+| 19 | MLA attention | | |
+| 20 | MoE routing (softmax+topK) | | |
+| 21 | MoE routing (noaux_tc sigmoid+bias) | | |
+| 22 | Shared expert | | |
+| 23 | Embed tensor `>2GB` load (chunked pread) | | |
+| 24 | Per-substep oracle validation | | |
+| 25 | Per-layer L2 sanity vs oracle | | |
+| 26 | End-to-end top-1 bit-match vs oracle | | |
+| 27 | K-head replication correctness | | |
+| 28 | Conv1d output position handling | | |
+| 29 | Weight absorption (`W_Q_abs`, `W_O_abs`) | | |
+| 30 | Build target in Makefile | | |
+
+## Models
+
+List models known to run on this port. Empty = none verified.
+
+| Model | Status | tok/s (warm) | Last verified |
+|---|---|---|---|
+| | | | |
+
+## Known-good commit
+
+`<commit-hash> — short description of last working state>`
+
+## Backlinks
+
+- [`../STATUS.md`](../STATUS.md) — coarse project capability matrix

--- a/docs/ports/cuda.md
+++ b/docs/ports/cuda.md
@@ -1,0 +1,58 @@
+# Port: cuda
+
+> **Branch:** `cuda`
+> **Status:** stub — fill cells as capabilities are verified.
+> **Coarse summary:** see [`../STATUS.md`](../STATUS.md).
+
+## Capability matrix (detailed)
+
+Cell values: ✅ verified  ·  🟡 partial / unstable  ·  ❌ broken / missing  ·  `—` N/A.
+
+| # | Capability | Per-model status | Notes |
+|---|---|---|---|
+| 1 | Model loads end-to-end | | |
+| 2 | Greedy sampling | | |
+| 3 | Top-p / temperature sampling | | |
+| 4 | Tokenizer subprocess | | |
+| 5 | Tool calling (JSON-stable) | | |
+| 6 | Multi-turn agent loop | | |
+| 7 | HTTP/SSE serve mode | | |
+| 8 | Streaming SSD experts | | |
+| 9 | VRAM/RAM LRU expert cache | | |
+| 10 | int4 quant (custom pack) | | |
+| 11 | FP8 e4m3 block-128 quant | | |
+| 12 | sym-int4 (compressed-tensors) | | |
+| 13 | RoPE (full) | | |
+| 14 | RoPE (partial) | | |
+| 15 | RMSNorm (standard) | | |
+| 16 | RMSNorm-plus-one variant | | |
+| 17 | GatedDeltaNet (linear attention) | | |
+| 18 | Full attention with output-gate | | |
+| 19 | MLA attention | | |
+| 20 | MoE routing (softmax+topK) | | |
+| 21 | MoE routing (noaux_tc sigmoid+bias) | | |
+| 22 | Shared expert | | |
+| 23 | Embed tensor `>2GB` load (chunked pread) | | |
+| 24 | Per-substep oracle validation | | |
+| 25 | Per-layer L2 sanity vs oracle | | |
+| 26 | End-to-end top-1 bit-match vs oracle | | |
+| 27 | K-head replication correctness | | |
+| 28 | Conv1d output position handling | | |
+| 29 | Weight absorption (`W_Q_abs`, `W_O_abs`) | | |
+| 30 | Build target in Makefile | | |
+
+## Models
+
+List models known to run on this port. Empty = none verified.
+
+| Model | Status | tok/s (warm) | Last verified |
+|---|---|---|---|
+| | | | |
+
+## Known-good commit
+
+`<commit-hash> — short description of last working state>`
+
+## Backlinks
+
+- [`../STATUS.md`](../STATUS.md) — coarse project capability matrix

--- a/docs/ports/metal.md
+++ b/docs/ports/metal.md
@@ -1,0 +1,58 @@
+# Port: metal
+
+> **Branch:** `main`
+> **Status:** stub — fill cells as capabilities are verified.
+> **Coarse summary:** see [`../STATUS.md`](../STATUS.md).
+
+## Capability matrix (detailed)
+
+Cell values: ✅ verified  ·  🟡 partial / unstable  ·  ❌ broken / missing  ·  `—` N/A.
+
+| # | Capability | Per-model status | Notes |
+|---|---|---|---|
+| 1 | Model loads end-to-end | | |
+| 2 | Greedy sampling | | |
+| 3 | Top-p / temperature sampling | | |
+| 4 | Tokenizer subprocess | | |
+| 5 | Tool calling (JSON-stable) | | |
+| 6 | Multi-turn agent loop | | |
+| 7 | HTTP/SSE serve mode | | |
+| 8 | Streaming SSD experts | | |
+| 9 | VRAM/RAM LRU expert cache | | |
+| 10 | int4 quant (custom pack) | | |
+| 11 | FP8 e4m3 block-128 quant | | |
+| 12 | sym-int4 (compressed-tensors) | | |
+| 13 | RoPE (full) | | |
+| 14 | RoPE (partial) | | |
+| 15 | RMSNorm (standard) | | |
+| 16 | RMSNorm-plus-one variant | | |
+| 17 | GatedDeltaNet (linear attention) | | |
+| 18 | Full attention with output-gate | | |
+| 19 | MLA attention | | |
+| 20 | MoE routing (softmax+topK) | | |
+| 21 | MoE routing (noaux_tc sigmoid+bias) | | |
+| 22 | Shared expert | | |
+| 23 | Embed tensor `>2GB` load (chunked pread) | | |
+| 24 | Per-substep oracle validation | | |
+| 25 | Per-layer L2 sanity vs oracle | | |
+| 26 | End-to-end top-1 bit-match vs oracle | | |
+| 27 | K-head replication correctness | | |
+| 28 | Conv1d output position handling | | |
+| 29 | Weight absorption (`W_Q_abs`, `W_O_abs`) | | |
+| 30 | Build target in Makefile | | |
+
+## Models
+
+List models known to run on this port. Empty = none verified.
+
+| Model | Status | tok/s (warm) | Last verified |
+|---|---|---|---|
+| | | | |
+
+## Known-good commit
+
+`<commit-hash> — short description of last working state>`
+
+## Backlinks
+
+- [`../STATUS.md`](../STATUS.md) — coarse project capability matrix

--- a/docs/ports/mi300-opt.md
+++ b/docs/ports/mi300-opt.md
@@ -1,0 +1,58 @@
+# Port: mi300-opt
+
+> **Branch:** `mi300-opt`
+> **Status:** stub — fill cells as capabilities are verified.
+> **Coarse summary:** see [`../STATUS.md`](../STATUS.md).
+
+## Capability matrix (detailed)
+
+Cell values: ✅ verified  ·  🟡 partial / unstable  ·  ❌ broken / missing  ·  `—` N/A.
+
+| # | Capability | Per-model status | Notes |
+|---|---|---|---|
+| 1 | Model loads end-to-end | | |
+| 2 | Greedy sampling | | |
+| 3 | Top-p / temperature sampling | | |
+| 4 | Tokenizer subprocess | | |
+| 5 | Tool calling (JSON-stable) | | |
+| 6 | Multi-turn agent loop | | |
+| 7 | HTTP/SSE serve mode | | |
+| 8 | Streaming SSD experts | | |
+| 9 | VRAM/RAM LRU expert cache | | |
+| 10 | int4 quant (custom pack) | | |
+| 11 | FP8 e4m3 block-128 quant | | |
+| 12 | sym-int4 (compressed-tensors) | | |
+| 13 | RoPE (full) | | |
+| 14 | RoPE (partial) | | |
+| 15 | RMSNorm (standard) | | |
+| 16 | RMSNorm-plus-one variant | | |
+| 17 | GatedDeltaNet (linear attention) | | |
+| 18 | Full attention with output-gate | | |
+| 19 | MLA attention | | |
+| 20 | MoE routing (softmax+topK) | | |
+| 21 | MoE routing (noaux_tc sigmoid+bias) | | |
+| 22 | Shared expert | | |
+| 23 | Embed tensor `>2GB` load (chunked pread) | | |
+| 24 | Per-substep oracle validation | | |
+| 25 | Per-layer L2 sanity vs oracle | | |
+| 26 | End-to-end top-1 bit-match vs oracle | | |
+| 27 | K-head replication correctness | | |
+| 28 | Conv1d output position handling | | |
+| 29 | Weight absorption (`W_Q_abs`, `W_O_abs`) | | |
+| 30 | Build target in Makefile | | |
+
+## Models
+
+List models known to run on this port. Empty = none verified.
+
+| Model | Status | tok/s (warm) | Last verified |
+|---|---|---|---|
+| | | | |
+
+## Known-good commit
+
+`<commit-hash> — short description of last working state>`
+
+## Backlinks
+
+- [`../STATUS.md`](../STATUS.md) — coarse project capability matrix

--- a/docs/ports/rocm.md
+++ b/docs/ports/rocm.md
@@ -1,0 +1,58 @@
+# Port: rocm
+
+> **Branch:** `rocm`
+> **Status:** stub — fill cells as capabilities are verified.
+> **Coarse summary:** see [`../STATUS.md`](../STATUS.md).
+
+## Capability matrix (detailed)
+
+Cell values: ✅ verified  ·  🟡 partial / unstable  ·  ❌ broken / missing  ·  `—` N/A.
+
+| # | Capability | Per-model status | Notes |
+|---|---|---|---|
+| 1 | Model loads end-to-end | | |
+| 2 | Greedy sampling | | |
+| 3 | Top-p / temperature sampling | | |
+| 4 | Tokenizer subprocess | | |
+| 5 | Tool calling (JSON-stable) | | |
+| 6 | Multi-turn agent loop | | |
+| 7 | HTTP/SSE serve mode | | |
+| 8 | Streaming SSD experts | | |
+| 9 | VRAM/RAM LRU expert cache | | |
+| 10 | int4 quant (custom pack) | | |
+| 11 | FP8 e4m3 block-128 quant | | |
+| 12 | sym-int4 (compressed-tensors) | | |
+| 13 | RoPE (full) | | |
+| 14 | RoPE (partial) | | |
+| 15 | RMSNorm (standard) | | |
+| 16 | RMSNorm-plus-one variant | | |
+| 17 | GatedDeltaNet (linear attention) | | |
+| 18 | Full attention with output-gate | | |
+| 19 | MLA attention | | |
+| 20 | MoE routing (softmax+topK) | | |
+| 21 | MoE routing (noaux_tc sigmoid+bias) | | |
+| 22 | Shared expert | | |
+| 23 | Embed tensor `>2GB` load (chunked pread) | | |
+| 24 | Per-substep oracle validation | | |
+| 25 | Per-layer L2 sanity vs oracle | | |
+| 26 | End-to-end top-1 bit-match vs oracle | | |
+| 27 | K-head replication correctness | | |
+| 28 | Conv1d output position handling | | |
+| 29 | Weight absorption (`W_Q_abs`, `W_O_abs`) | | |
+| 30 | Build target in Makefile | | |
+
+## Models
+
+List models known to run on this port. Empty = none verified.
+
+| Model | Status | tok/s (warm) | Last verified |
+|---|---|---|---|
+| | | | |
+
+## Known-good commit
+
+`<commit-hash> — short description of last working state>`
+
+## Backlinks
+
+- [`../STATUS.md`](../STATUS.md) — coarse project capability matrix


### PR DESCRIPTION
## Summary

- Adds `docs/STATUS.md` — coarse "what works on which backend, with which model" matrix (15 capabilities × 12 backend×model combinations).
- Adds `docs/ports/<port>.md` — per-port detailed matrix stubs; `cuda-qwen36.md` (priority port) is filled in with real data.
- Adds `.github/PULL_REQUEST_TEMPLATE.md` enforcing the two propagation questions on every PR.
- Links `docs/STATUS.md` from `CLAUDE.md` (= `README.md` symlink) so it's the discoverable answer to "what does this project do."
- Adds a `.gitignore` rule for `docs/superpowers/` and `docs/plan-*.md` so future strategy work stays local.

The underlying design spec and implementation plan are intentionally not in this diff — they are local working notes, gitignored. GitHub labels (`port:*`, `propagate:*`, `reliability`, `correctness`, `tool-calling`, `infra`, `port-only`) and 5 seed issues (#1-#5) are created out-of-band; they are not part of this PR diff either.

Honest note on the matrix: every formerly-✅ cell is now 🟡 because no port has cleared the project's reliability bar (multi-turn agent loop + small fixed eval) yet. ✅ stays reserved until a port can demonstrate that bar.

## Coherence checklist

- [x] **Did this change a \`docs/STATUS.md\` cell?** Yes — created the file. Initial values reflect current truth across all branches as of 2026-04-27.
- [x] **Does this fix or add something that should propagate to other ports?** No — this is doc-only infrastructure. The seed issues (#1-#5) carry the propagation work.

## Affected ports / branches

This PR is doc-only and lands on \`main\`; no port code is touched. The matrix references all current ports (\`metal\`, \`cuda\`, \`cuda-qwen36\`, \`cuda-kimi\`, \`rocm\`, \`mi300-opt\`, \`apu\`).

## Reliability impact

Setup work — does not move any port toward the reliability bar by itself, but creates the visibility and discipline that the post-hackathon reliability sprint depends on.

## Linked issues

See open issues with \`reliability\` and \`infra\` labels (#1-#5).

## Test plan

- [ ] \`grep -c '\[?\]' docs/STATUS.md\` returns 0
- [ ] All 7 \`docs/ports/<port>.md\` files exist
- [ ] \`gh label list --repo ssubbotin/flash-moe | grep -E "^(port:|propagate:)"\` returns 14 lines
- [ ] \`gh issue list --repo ssubbotin/flash-moe --state open --limit 100 | wc -l\` returns >= 5
- [ ] README symlink resolves and "## Project status" section is grep-able