### PR TITLE
docs: expand README — multi-backend reality, branches, contributors

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,6 +6,8 @@ Pure C/Metal inference engine that runs **Qwen3.5-397B-A17B** (a 397 billion par
 
 The entire 209GB model streams from SSD through a custom Metal compute pipeline. No Python. No frameworks. Just C, Objective-C, and hand-tuned Metal shaders.
 
+The project has since expanded to a CUDA backend (RTX 4090 / 5090 / PRO 6000), a ROCm backend (MI300X), and additional MoE families (Qwen3.6-35B-A3B-FP8, Kimi K2.6). See [Backends & ports](#backends--ports) below for what runs where.
+
 ## Project status
 
 **What works on which backend, with which model:** see [`docs/STATUS.md`](docs/STATUS.md).
@@ -14,7 +16,22 @@ Per-port detail in [`docs/ports/<port>.md`](docs/ports/).
 
 A cell is allowed to be ✅ only when the model on that backend has cleared the project reliability bar: a multi-turn agent loop (5+ tool calls, file edits, no drift) plus a small fixed eval. Working mechanism without that test stays 🟡.
 
-## Results
+## Backends & ports
+
+| Backend | Branch | Hardware | Model | tok/s (warm) | Notes |
+|---|---|---|---|---|---|
+| Metal | `main` | M3 Max 48GB | Qwen3.5-397B-A17B | 4.36 (4-bit) | Production reference. Tool calling. The paper. |
+| CUDA | `cuda` | RTX 4090 / 5090 / PRO 6000 | Qwen3.5-397B-A17B | 1.75 (4090) → 10.57 peak (5090) → 43.2 cached (PRO 6000 96 GB) | Multi-hardware benchmarks. |
+| CUDA | `cuda-qwen36` | RTX 4090 | Qwen3.6-35B-A3B-FP8 | ~7-8 | FP8 e4m3 + VRAM LRU expert cache. |
+| CUDA | `cuda-kimi` | RTX PRO 6000 (96GB) | Kimi K2.6 (1T MoE) | — | Active development; hidden-state collapse between L1 and L5 under investigation ([#1](https://github.com/ssubbotin/flash-moe/issues/1)). |
+| ROCm | `rocm`, `mi300-opt` | MI300X 192GB | Qwen3-235B-A22B | 7.13 (30 tok) → 8.99 (100 tok) | Optimization targeting AMD Developer Hackathon (May 2026). |
+| APU | `apu` | Strix Halo (exploratory) | — | — | Unified-memory APU evaluation. |
+
+**Open work:** see [open issues](https://github.com/ssubbotin/flash-moe/issues) (filter by `reliability`, `correctness`, or `port:*` labels). The current priority is getting Qwen3.6 on `cuda-qwen36` to clear the reliability bar — multi-turn agent loop + small fixed eval ([#5](https://github.com/ssubbotin/flash-moe/issues/5)).
+
+**Branch lifecycle:** the model branches above (`cuda-qwen36`, `cuda-kimi`, `mi300-opt`, `apu`) carry their per-port working state and have not been merged into `main`. `main` carries the Metal reference engine and the project-wide capability matrix; per-port code is read directly off its branch. Cross-branch fixes propagate via labeled issues — see the [PR template](.github/PULL_REQUEST_TEMPLATE.md) and the `port:*` / `propagate:*` labels.
+
+## Results — Metal × Qwen3.5-397B (M3 Max, 4-bit production config)
 
 ![Progress](progress.png)
 
@@ -27,13 +44,15 @@ A cell is allowed to be ✅ only when the model on that backend has cleared the 
 
 *2-bit quantization produces `\name\` instead of `"name"` in JSON output, making tool calling unreliable. 4-bit is the production configuration.
 
-## Hardware
+## Hardware (Metal reference)
 
 - **Machine**: MacBook Pro, Apple M3 Max
 - **Chip**: 16-core CPU (12P + 4E), 40-core GPU, 16-core ANE
 - **Memory**: 48 GB unified (~400 GB/s bandwidth)
 - **SSD**: 1TB Apple Fabric, **17.5 GB/s sequential read** (measured)
 - **macOS**: 26.2 (Darwin 25.2.0)
+
+For other hardware configurations (RTX 4090 / 5090 / PRO 6000 / MI300X), see the per-port docs under [`docs/ports/`](docs/ports/).
 
 ## Architecture
 
@@ -76,6 +95,8 @@ On Apple Silicon, SSD DMA and GPU compute share the same memory controller and c
 
 ## Quick Start
 
+### Metal (M3 Max → Qwen3.5-397B)
+
 ```bash
 cd metal_infer
 make
@@ -92,30 +113,52 @@ make
 ./infer --prompt "Hello" --tokens 20 --timing
 ```
 
+### CUDA (NVIDIA GPUs)
+
+The CUDA backend lives in `cuda_infer/` on branches `cuda` (Qwen3.5-397B), `cuda-qwen36` (Qwen3.6-35B-A3B-FP8), and `cuda-kimi` (Kimi K2.6 — under active development). Build with `make` from `cuda_infer/`; requires CUDA 12.8+ and libcufile. Per-branch run commands live in [`docs/ports/cuda*.md`](docs/ports/) and `cuda_infer/README.md`.
+
+### ROCm (AMD GPUs)
+
+The ROCm backend lives in `rocm_infer/` on branches `rocm` and `mi300-opt`. Build with `make` from `rocm_infer/` on MI300X (gfx942, ROCm 7.2+). Run commands in [`docs/ports/rocm.md`](docs/ports/rocm.md) and [`docs/ports/mi300-opt.md`](docs/ports/mi300-opt.md).
+
 ## Project Structure
 
 ```
-metal_infer/
-  infer.m              # Complete inference engine (~7000 lines)
-  shaders.metal        # Metal compute kernels (~1200 lines)
-  chat.m               # Interactive chat TUI with tool calling
-  tokenizer.h          # C BPE tokenizer (single-header, 449 lines)
-  main.m               # MoE-only benchmark
-  Makefile             # Build system
-  extract_weights.py   # Creates model_weights.bin from safetensors
-  repack_experts_2bit.py  # 4-bit → 2-bit expert requantization
-  train_predictor.py   # Expert routing prediction analysis
-  model_weights.bin    # Non-expert weights (5.5GB, mmap'd)
-  model_weights.json   # Tensor manifest
-  vocab.bin            # Vocabulary for token decoding
-  tokenizer.bin        # Pre-exported BPE tokenizer data
+metal_infer/             # Metal backend — main branch
+  infer.m                # Complete inference engine (~7000 lines)
+  shaders.metal          # Metal compute kernels (~1200 lines)
+  chat.m                 # Interactive chat TUI with tool calling
+  tokenizer.h            # C BPE tokenizer (single-header, 449 lines)
+  main.m                 # MoE-only benchmark
+  Makefile               # Build system
+  extract_weights.py     # Creates model_weights.bin from safetensors
+  repack_experts_2bit.py # 4-bit → 2-bit expert requantization
+  train_predictor.py     # Expert routing prediction analysis
 
-repack_experts.py      # 4-bit expert packing from safetensors
-progress.py            # Results visualization (Q2/Q4 tracks)
-results.tsv            # Experiment log (58 experiments)
+cuda_infer/              # CUDA backend — branches cuda, cuda-qwen36, cuda-kimi
+                         # Per-model engines and FP8 / sym-int4 dequant kernels.
+
+rocm_infer/              # ROCm/HIP backend — branches rocm, mi300-opt
+                         # MI300X port; aotriton attention, FLA mapping.
+
+apu_infer/               # APU exploration — branch apu
+
+docs/
+  STATUS.md              # Coarse capability matrix (canonical "what works")
+  ports/<port>.md        # Per-port detailed matrix and run commands
+  mi300/                 # MI300-specific notes (aotriton API, FLA mapping)
+
+paper/                   # Flash-MoE paper sources (LaTeX, arXiv, TMLR variants)
+progress.py              # Results visualization (Q2/Q4 tracks)
+results.tsv              # Experiment log (Metal track)
+repack_experts.py        # 4-bit expert packing from safetensors (Metal)
+repack_experts_kimi.py   # sym-int4 expert packing for Kimi
+repack_experts_qwen36.py # FP8 expert packing for Qwen3.6
 ```
 
-## What We Tried (and What Worked)
+## What We Tried (and What Worked) — Metal track
+
+The tables below cover the Metal × Qwen3.5-397B optimization track (the paper's subject). CUDA, ROCm, and per-port-model experiment logs live in their respective branches and per-port docs.
 
 ### Kept
 | Approach | Result | Impact |
@@ -144,6 +187,14 @@ results.tsv            # Experiment log (58 experiments)
 | mmap expert files | -5x | Per-page fault overhead on cold data |
 | Speculative early routing | -38% | Cache pollution + overhead |
 | MTP speculative decoding | break-even | MoE I/O scales per-token (unlike dense) |
+
+## Contributors
+
+**Daniel Woods** ([@danveloper](https://github.com/danveloper)) — original Flash-MoE author. Designed and implemented the Metal inference engine, the SSD-streamed expert pipeline, the Q4/Q2 quantization tracks, and the multi-hardware foundations. Co-author of the [paper](paper/flash_moe.pdf).
+
+**Sergey Subbotin** ([@ssubbotin](https://github.com/ssubbotin)) — fork maintainer. CUDA backend (RTX 4090 / 5090 / PRO 6000), ROCm/HIP backend (MI300X, gfx942), MI300 optimization plan, additional MoE family ports (Qwen3.6-35B-A3B-FP8, Kimi K2.6), multi-hardware benchmarks, and the project coherence system (`docs/STATUS.md`, per-port docs, propagation labels).
+
+The original 397B-on-MacBook story and its 24-hour collaboration narrative are documented in the [paper](paper/flash_moe.pdf).
 
 ## Safety
 


### PR DESCRIPTION
## Summary

- **Lede**: keeps the Metal × 397B headline (canonical Flash-MoE story / paper subject) and adds one sentence acknowledging the project has expanded to CUDA, ROCm, and additional MoE families.
- **New "Backends & ports" section**: table mapping backend × branch × hardware × model × tok/s, plus a paragraph on branch lifecycle and where to find open work.
- **Scoped existing sections**: `Results`, `Hardware`, and `What We Tried` are now explicitly labelled as the Metal × Qwen3.5-397B track they actually describe.
- **Quick Start**: adds CUDA and ROCm subsections pointing at per-port docs.
- **Project Structure**: reflects `cuda_infer/`, `rocm_infer/`, `apu_infer/`, `docs/STATUS.md`, `docs/ports/`, and the multiple repack scripts.
- **Contributors section**: crediting Daniel Woods ([@danveloper](https://github.com/danveloper)) as original author of the Metal engine, SSD pipeline, and paper, and Sergey Subbotin ([@ssubbotin](https://github.com/ssubbotin)) as fork maintainer for the CUDA / ROCm backends, additional MoE ports, multi-hardware benchmarks, and coherence system.

The original "an AI and a human built this in 24 hours" narrative and the paper attribution remain unchanged.

## Coherence checklist

- [ ] **Did this change a `docs/STATUS.md` cell?** No — README-only.
- [ ] **Does this fix or add something that should propagate to other ports?** No — README lives on `main` only.

## Affected ports / branches

This PR is doc-only, lands on `main`. References all ports in the new table.

## Reliability impact

None directly — but the new Backends & ports section makes it explicit that no port has cleared the reliability bar (every cell in `docs/STATUS.md` is 🟡, not ✅), preempting the "what does ✅ mean?" question for new readers.

## Linked issues

References open issues #1 and #5 in the Backends & ports table for current state of `cuda-kimi` (collapse bug) and the priority Qwen3.6 reliability work.

## Test plan

- [ ] README still renders cleanly on github.com (anchor `#backends--ports` resolves)
- [ ] No links to local-only paths (no `docs/superpowers/...`, no absolute home paths)
- [ ] Contributors section credits both authors with scoped contributions
- [ ] `grep -c "docs/superpowers" CLAUDE.md` returns 0